### PR TITLE
Support Android API < 28 

### DIFF
--- a/compose-shadow/src/androidMain/kotlin/com/adamglin/composeshadow/SoftLayerShadowContainer.kt
+++ b/compose-shadow/src/androidMain/kotlin/com/adamglin/composeshadow/SoftLayerShadowContainer.kt
@@ -1,0 +1,26 @@
+package com.adamglin.composeshadow
+
+import android.os.Build
+import android.view.View
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.viewinterop.AndroidView
+
+@Composable
+fun SoftLayerShadowContainer(content: @Composable () -> Unit) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+        AndroidView(
+            factory = { context ->
+                ComposeView(context).apply {
+                    setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+                    setContent(content)
+                }
+            },
+            modifier = Modifier.fillMaxSize()
+        )
+    } else {
+        content()
+    }
+}

--- a/compose-shadow/src/androidMain/kotlin/com/adamglin/composeshadow/softShadow.kt
+++ b/compose-shadow/src/androidMain/kotlin/com/adamglin/composeshadow/softShadow.kt
@@ -1,0 +1,105 @@
+package com.adamglin.composeshadow
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.*
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import com.adamglin.composeshadow.utils.spreadScale
+
+
+/**
+ * A [NativePaint.setShadowLayer]/[View.LAYER_TYPE_SOFTWARE] layer type based shadow [Modifier].
+ *
+ * You must use it with [SoftLayerShadowContainer].
+ *
+ * @param radius The shadow radius.
+ * @param color The shadow color.
+ * @param shape The shadow shape.
+ * @param spread The shadow spread.
+ * @param offset The shadow offset.
+ * @param isAlphaContentClip Indicates whether the alpha (transparent) content should be clipped to the [shape].
+ * @return The applied SoftLayerShadow [Modifier].
+ * @see SoftLayerShadowContainer
+ * @author GIGAMOLE
+ */
+fun Modifier.softLayerShadow(
+    shape: Shape,
+    radius: Dp = 4.dp,
+    color: Color = Color.Black.copy(0.25f),
+    spread: Dp = 4.dp,
+    offset: DpOffset = DpOffset(4.dp, 4.dp),
+): Modifier = this.drawWithCache {
+    val radiusPx = radius.toPx()
+    val isRadiusValid = radiusPx > 0.0F
+    val paint = Paint().apply {
+        this.color = if (isRadiusValid) {
+            Color.Transparent
+        } else {
+            color
+        }
+
+        asFrameworkPaint().apply {
+            isDither = true
+            isAntiAlias = true
+
+            if (isRadiusValid) {
+                setShadowLayer(
+                    radiusPx,
+                    offset.x.toPx(),
+                    offset.y.toPx(),
+                    color.toArgb()
+                )
+            }
+        }
+    }
+    val shapeOutline = shape.createOutline(
+        size = size,
+        layoutDirection = LayoutDirection.Rtl,
+        density = this
+    )
+    val shapePath = Path().apply {
+        addOutline(outline = shapeOutline)
+    }
+
+    val drawShadowBlock: DrawScope.() -> Unit = {
+        drawIntoCanvas { canvas ->
+            canvas.withSave {
+                if (isRadiusValid.not()) {
+                    canvas.translate(
+                        dx = offset.x.toPx(),
+                        dy = offset.y.toPx()
+                    )
+                }
+
+                if (spread.value != 0.0F) {
+                    canvas.scale(
+                        sx = spreadScale(
+                            spread = spread.toPx(),
+                            size = size.width
+                        ),
+                        sy = spreadScale(
+                            spread = spread.toPx(),
+                            size = size.height
+                        ),
+                        pivotX = center.x,
+                        pivotY = center.y
+                    )
+                }
+
+                canvas.drawOutline(
+                    outline = shapeOutline,
+                    paint = paint
+                )
+            }
+        }
+    }
+
+    onDrawBehind {
+        drawShadowBlock()
+    }
+}

--- a/compose-shadow/src/commonMain/kotlin/com/adamglin/composeshadow/utils/spreadScale.kt
+++ b/compose-shadow/src/commonMain/kotlin/com/adamglin/composeshadow/utils/spreadScale.kt
@@ -1,0 +1,16 @@
+package com.adamglin.composeshadow.utils
+
+/**
+ * Calculates shadow spread scale.
+ *
+ * @param spread The raw spread.
+ * @param size The X or Y side.
+ * @return The shadow spread scale.
+ * @see com.gigamole.composeshadowsplus.rsblur.rsBlurShadow
+ * @see com.gigamole.composeshadowsplus.softlayer.softLayerShadow
+ * @author GIGAMOLE
+ */
+internal fun spreadScale(
+    spread: Float,
+    size: Float
+): Float = 1.0F + ((spread / size) * 2.0F)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 #android
 androidCompileSdk = "35"
-androidMinSdk = "28"
+androidMinSdk = "21"
 androidTargetSdk = "35"
 androidGradlePlugin = "8.6.1"
 #androidx

--- a/sample/compose-app/src/androidMain/kotlin/com/adamglin/composeshadow/app/MainActivity.kt
+++ b/sample/compose-app/src/androidMain/kotlin/com/adamglin/composeshadow/app/MainActivity.kt
@@ -1,17 +1,64 @@
 package com.adamglin.composeshadow.app
 
 import SampleApp
+import android.graphics.drawable.shapes.Shape
+import android.os.Build
 import android.os.Bundle
+import android.view.View
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.adamglin.composeshadow.softLayerShadow
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            SampleApp()
+            Column {
+                SoftLayerShadowContainer{
+                    Box(
+                        modifier = Modifier
+                            .padding(40.dp)
+                            .softLayerShadow(
+                                shape = RoundedCornerShape(4.dp)
+                            )
+                            .requiredSize(100.dp)
+                            .background(Color.White)
+                    )
+                }
+                SampleApp()
+            }
         }
+    }
+}
+
+@Composable
+fun SoftLayerShadowContainer(content: @Composable () -> Unit) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+        AndroidView(
+            factory = { context ->
+                ComposeView(context).apply {
+                    setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+                    setContent(content)
+                }
+            }
+        )
+    } else {
+        content()
     }
 }

--- a/sample/compose-app/src/androidMain/kotlin/com/adamglin/composeshadow/app/MainActivity.kt
+++ b/sample/compose-app/src/androidMain/kotlin/com/adamglin/composeshadow/app/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.adamglin.composeshadow.SoftLayerShadowContainer
 import com.adamglin.composeshadow.softLayerShadow
 
 class MainActivity : ComponentActivity() {
@@ -29,8 +30,9 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            Column {
-                SoftLayerShadowContainer{
+            SoftLayerShadowContainer{
+                Column {
+
                     Box(
                         modifier = Modifier
                             .padding(40.dp)
@@ -40,25 +42,10 @@ class MainActivity : ComponentActivity() {
                             .requiredSize(100.dp)
                             .background(Color.White)
                     )
+                    SampleApp()
                 }
-                SampleApp()
             }
         }
     }
 }
 
-@Composable
-fun SoftLayerShadowContainer(content: @Composable () -> Unit) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-        AndroidView(
-            factory = { context ->
-                ComposeView(context).apply {
-                    setLayerType(View.LAYER_TYPE_SOFTWARE, null)
-                    setContent(content)
-                }
-            }
-        )
-    } else {
-        content()
-    }
-}


### PR DESCRIPTION
1. The initial code is copied from composeShadowPlus. (So I should add a license in the code file.)

2. If android sdk < 28, the content should be wrapped with AndroidView and the LayerType should be set to LAYER_TYPE_SOFTWARE.

3. `compose-shadow` should provide a wrapper component to wrap content like ComposeShadowPlus.

4. It seems that the shadow drawn by the composeShadowPlus solution is different in android 27 and android 28.

## Summary by Sourcery

Enable backward-compatible soft shadows on pre-API 28 devices by introducing a software-rendered ComposeView wrapper and custom shadow modifier, and update the sample app accordingly.

New Features:
- Add softLayerShadow modifier to draw shadows using NativePaint.setShadowLayer in Compose.
- Introduce SoftLayerShadowContainer composable to wrap content in a software-rendered ComposeView on Android versions below API 28.
- Add spreadScale utility function for calculating shadow spread scaling.

Enhancements:
- Update the sample MainActivity to demonstrate the new softLayerShadow within the SoftLayerShadowContainer.

Build:
- Lower Android minSdk version from 28 to 21.