### PR TITLE
deps update

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,20 +5,20 @@ androidMinSdk = "21"
 androidTargetSdk = "35"
 androidGradlePlugin = "8.6.1"
 #androidx
-androidxActivity = "1.10.0"
+androidxActivity = "1.10.1"
 androidxAppCompat = "1.7.0"
-androidxMacroBenchmark = "1.3.3"
+androidxMacroBenchmark = "1.3.4"
 androidxAnnotation = "1.9.1"
 #kotlin
-kotlin = "2.1.10"
-kotlinx-coroutine = "1.10.1"
+kotlin = "2.1.21"
+kotlinx-coroutine = "1.10.2"
 binaryCompatibilityValidator = "0.17.0"
 #compose
-composeMultiplatform = "1.7.3"
+composeMultiplatform = "1.8.1"
 colorpicker="1.1.2"
 #other
 dokka = "2.0.0"
-mavenPublish = "0.30.0"
+mavenPublish = "0.31.0"
 [libraries]
 #androidx
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ androidxMacroBenchmark = "1.3.4"
 androidxAnnotation = "1.9.1"
 #kotlin
 kotlin = "2.1.21"
-kotlinx-coroutine = "1.10.2"
+kotlinx-coroutines = "1.10.2"
 binaryCompatibilityValidator = "0.17.0"
 #compose
 composeMultiplatform = "1.8.1"
@@ -25,8 +25,8 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidxAnnotation" }
 # kotlin
-kotlinx-coroutine-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutine" }
-kotlinx-coroutine-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutine" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 colorPicker = { module = "com.github.skydoves:colorpicker-compose", version.ref = "colorpicker" }
 [plugins]
 #android

--- a/sample/compose-app/build.gradle.kts
+++ b/sample/compose-app/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
     }
 
     js(IR) {
-        moduleName = "sharedApp"
+        outputModuleName = "sharedApp"
         browser {
             commonWebpackConfig {
                 outputFileName = "sharedApp.js"
@@ -44,7 +44,7 @@ kotlin {
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
-        moduleName = "sharedApp"
+        outputModuleName = "sharedApp"
         browser {
             commonWebpackConfig {
                 outputFileName = "sharedApp.js"
@@ -68,7 +68,7 @@ kotlin {
 
         desktopMain.dependencies {
             implementation(compose.desktop.currentOs)
-            implementation(libs.kotlinx.coroutine.swing)
+            implementation(libs.kotlinx.coroutines.swing)
         }
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

to fix #50 

Update project dependencies to their latest versions

Chores:
- Bump androidx Activity to 1.10.1
- Bump androidx MacroBenchmark to 1.3.4
- Bump Kotlin to 2.1.21 and kotlinx-coroutine to 1.10.2
- Bump Compose Multiplatform to 1.8.1
- Bump Maven Publish plugin to 0.31.0
